### PR TITLE
Fix Clarinet installation in deploy-testnet workflow

### DIFF
--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -64,11 +64,16 @@ jobs:
           cache-dependency-path: package-lock.json
       - name: Install Dependencies
         run: npm ci --no-audit --no-fund
+      - name: Install Clarinet
+        run: |
+          curl -L https://github.com/hirosystems/clarinet/releases/download/v2.9.0/clarinet-linux-x64.tar.gz | tar xz
+          sudo mv clarinet /usr/local/bin/clarinet
+          chmod +x /usr/local/bin/clarinet
       - name: Verify Clarinet Installation
-        run: npx clarinet --version
+        run: clarinet --version
       - name: Compile Contracts
         timeout-minutes: 5
-        run: npx clarinet check
+        run: clarinet check
       - name: Artifact Summary
         run: |
           echo "Contracts:"; ls -1 contracts | wc -l
@@ -90,8 +95,13 @@ jobs:
           cache-dependency-path: package-lock.json
       - name: Install Dependencies
         run: npm ci --no-audit --no-fund
+      - name: Install Clarinet
+        run: |
+          curl -L https://github.com/hirosystems/clarinet/releases/download/v2.9.0/clarinet-linux-x64.tar.gz | tar xz
+          sudo mv clarinet /usr/local/bin/clarinet
+          chmod +x /usr/local/bin/clarinet
       - name: Verify Clarinet Installation
-        run: npx clarinet --version
+        run: clarinet --version
       - name: Deployment (Dry / Placeholder)
         run: |
           set -e


### PR DESCRIPTION
## Problem
The deployment workflow is failing because Clarinet is not properly installed in the GitHub Actions environment. The workflow was trying to use 
px clarinet which doesn't work since Clarinet isn't available as an npm package.

## Solution
- Install Clarinet binary directly from GitHub releases (v2.9.0)
- Replace 
px clarinet commands with direct clarinet commands
- Add proper installation steps to both prepare and deploy jobs

## Testing
This fix addresses the deployment failure seen in runs:
- 17541473318 (latest)
- 17541104347
- 17004681159

## Impact
- Unblocks testnet deployment
- Enables contract compilation and validation
- Critical for mainnet readiness validation