### PR TITLE
FINAL: Fix Clarinet filename to use glibc variant

### DIFF
--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -66,7 +66,7 @@ jobs:
         run: npm ci --no-audit --no-fund
       - name: Install Clarinet
         run: |
-          curl -L https://github.com/hirosystems/clarinet/releases/download/v3.5.0/clarinet-linux-x64.tar.gz | tar xz
+          curl -L https://github.com/hirosystems/clarinet/releases/download/v3.5.0/clarinet-linux-x64-glibc.tar.gz | tar xz
           sudo mv clarinet /usr/local/bin/clarinet
           chmod +x /usr/local/bin/clarinet
       - name: Verify Clarinet Installation
@@ -97,7 +97,7 @@ jobs:
         run: npm ci --no-audit --no-fund
       - name: Install Clarinet
         run: |
-          curl -L https://github.com/hirosystems/clarinet/releases/download/v3.5.0/clarinet-linux-x64.tar.gz | tar xz
+          curl -L https://github.com/hirosystems/clarinet/releases/download/v3.5.0/clarinet-linux-x64-glibc.tar.gz | tar xz
           sudo mv clarinet /usr/local/bin/clarinet
           chmod +x /usr/local/bin/clarinet
       - name: Verify Clarinet Installation


### PR DESCRIPTION
## Problem
Deployment still failing with 404 error - workflow is using clarinet-linux-x64.tar.gz which doesn't exist.

## Root Cause
Previous PR didn't apply correctly to all instances in the workflow file.

## Solution  
Replace all instances with clarinet-linux-x64-glibc.tar.gz - the actual filename in v3.5.0 releases.

## Verification
`ash
curl -s https://api.github.com/repos/hirosystems/clarinet/releases/tags/v3.5.0 | Select-String browser_download_url
`
Shows: clarinet-linux-x64-glibc.tar.gz ✅

## Impact
This is the final fix needed to unblock testnet deployment.