### PR TITLE
fix: install Clarinet in CI workflow before running clarinet:check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,13 @@ jobs:
           cache-dependency-path: package-lock.json
       - name: Install deps
         run: npm ci --no-audit --no-fund
+      - name: Install Clarinet
+        run: |
+          curl -L https://github.com/hirosystems/clarinet/releases/download/v3.5.0/clarinet-linux-x64-glibc.tar.gz | tar xz
+          sudo mv clarinet /usr/local/bin/clarinet
+          chmod +x /usr/local/bin/clarinet
+      - name: Verify Clarinet Installation
+        run: clarinet --version
       - name: Contract Compilation
         run: npm run clarinet:check
       - name: Docs and Naming Guard
@@ -44,6 +51,13 @@ jobs:
           cache-dependency-path: package-lock.json
       - name: Install deps
         run: npm ci --no-audit --no-fund
+      - name: Install Clarinet
+        run: |
+          curl -L https://github.com/hirosystems/clarinet/releases/download/v3.5.0/clarinet-linux-x64-glibc.tar.gz | tar xz
+          sudo mv clarinet /usr/local/bin/clarinet
+          chmod +x /usr/local/bin/clarinet
+      - name: Verify Clarinet Installation
+        run: clarinet --version
       - name: Verify Clarinet Binary
         run: npm run clarinet:check
       - name: Package


### PR DESCRIPTION
## Problem
CI tests are failing with clarinet: not found error when running 
pm run clarinet:check.

## Solution
- Add Clarinet installation step to both test and build jobs in CI workflow
- Download and install Clarinet v3.5.0 glibc variant for Ubuntu runners
- Verify installation before running contract compilation

## Impact
- Fixes failing Test and Build jobs in CI pipeline
- Ensures proper contract compilation validation
- Resolves PR check failures caused by missing Clarinet binary

## Testing
This change will be validated when CI runs on this PR and subsequent PRs.